### PR TITLE
Update DWDdata URLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: climateStripes
 Type: Package
 Title: Create climate plots for weather stations of DWD (German
     Meteorological Service)
-Version: 0.3.4
+Version: 0.3.5
 Author: c(person("Kai", "Budde", email = "kai.budde@uni-rostock.de",
     role = c("aut", "cre"))
 Maintainer: Kai Budde <kai.budde@uni-rostock.de>

--- a/inst/links.json
+++ b/inst/links.json
@@ -1,5 +1,5 @@
 {
 "DWDstations": "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/historical/KL_Tageswerte_Beschreibung_Stationen.txt",
-"DWDdata": "ftp://ftp-cdc.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/historical/",
-"DWDdata_recent":"ftp://ftp-cdc.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/recent/"
+"DWDdata": "ftp://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/historical/",
+"DWDdata_recent":"ftp://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/recent/"
 }


### PR DESCRIPTION
[Looks like](https://rcc.dwd.de/EN/climate_environment/cdc/news/news_node.html) they removed `ftp-cdc.dwd.de` a while ago:

> […] operation of the CDC FTP server ftp://ftp-cdc.dwd.de ended.

They might have inofficialy run them until recently, but when I tried your ["how to" instructions](https://github.com/buddekai/ClimateStripes#how-to-install-the-package-and-use-it) today, they yielded:

```
> climateStripes(city.name = "rostock")
Error in function (type, msg, asError = TRUE)  : 
  Could not resolve host: ftp-cdc.dwd.de
```

With this patch, the diagrams remain essentially the same, which I take as an end-to-end test ;-) Just a few pixels difference, here and there:

![diff](https://user-images.githubusercontent.com/17674964/113865957-07be9900-97ad-11eb-8df8-b8dc2aca7238.gif)
